### PR TITLE
ci: add nodejs v16 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [10.x, 12.x, 14.x]
+                node-version: [10, 12, 14, 16]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:


### PR DESCRIPTION
Node.js 16 is to be the next LTS version.