### PR TITLE
ci: use new automerge workflow for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
     - package-ecosystem: github-actions
-      directory: /
+      directory: '/'
       schedule:
           interval: monthly
       open-pull-requests-limit: 99
 
     - package-ecosystem: npm
-      directory: /
+      directory: '/'
       schedule:
           interval: monthly
       open-pull-requests-limit: 99

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,53 @@
+name: Automerge Dependabot PRs
+
+on:
+    workflow_run:
+        workflows: ['CI']
+        types: [completed]
+
+jobs:
+    on-success:
+        if: >
+            github.event.workflow_run.event == 'pull_request' && 
+            github.event.workflow_run.conclusion == 'success' &&
+            github.actor == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download Artifact
+              uses: actions/github-script@v4
+              with:
+                  script: |
+                      const fs = require('fs');
+
+                      const artifacts = await github.actions.listWorkflowRunArtifacts({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          run_id: ${{ github.event.workflow_run.id }},
+                      });
+                      const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+                          return artifact.name == 'pr';
+                      })[0];
+
+                      const download = await github.actions.downloadArtifact({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          artifact_id: matchArtifact.id,
+                          archive_format: 'zip',
+                      });
+
+                      fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            - run: unzip pr.zip
+            - name: Comment on PR
+              uses: actions/github-script@v4
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const fs = require('fs');
+                      const pull_number = Number(fs.readFileSync('./NR'));
+
+                      await github.pulls.merge({
+                          merge_method: "merge",
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: pull_number,
+                      });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,20 @@ jobs:
             - name: Run Tests
               run: npm test
 
-    automerge:
-        name: Automatically Merge Dependabot Pull Requests
-        if: github.event.pull_request.draft == false
-        needs: test
+    # This job is used to save the PR number in an artifact, for use in the automerge.yml workflow
+    save-pr-number:
+        name: Save PR Number
+        if: >
+            github.event.pull_request.draft == false && 
+            github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
-            - uses: fastify/github-action-merge-dependabot@v1.1.1
-              if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
+            - uses: actions/checkout@v2
+            - name: Save PR Number
+              run: |
+                  mkdir -p ./pr
+                  echo ${{ github.event.number }} > ./pr/NR
+            - uses: actions/upload-artifact@v2
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  name: pr
+                  path: pr/


### PR DESCRIPTION
GitHub has updated `pull_request` events so they now only have read access, which in turn has crippled `fastify/github-action-merge-dependabot` and any other automerging actions.

As [suggested by GitHub here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), the alternatives are to use `pull_request_target` or `workflow_run`.

This PR adds a new workflow (`automerge.yml`) that triggers if `ci.yml` job is a success and is a Dependabot update, and will automerge the PR.