### PR TITLE
build(dependabot): ignore minor and patch github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
     - package-ecosystem: github-actions
       directory: '/'
+      ignore:
+        - dependency-name: 'actions/*'
+          update-types:
+              ['version-update:semver-minor', 'version-update:semver-patch']
       schedule:
           interval: monthly
       open-pull-requests-limit: 99


### PR DESCRIPTION
GitHub introduced the [ability to ignore specific updates](https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/) back in May.
This PR should stop Dependabot flooding PRs (and release notes) with every minor and patch update of GitHub's own actions.