### PR TITLE
ci: reduce workflow permissions to minimum

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -50,7 +50,7 @@ jobs:
                       const pull_number = Number(fs.readFileSync('./NR'));
 
                       await github.rest.pulls.merge({
-                          merge_method: "merge",
+                          merge_method: "squash",
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           pull_number: pull_number,

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
     on-success:
         if: >
-            github.event.workflow_run.event == 'pull_request' && 
+            github.event.workflow_run.event == 'pull_request' &&
             github.event.workflow_run.conclusion == 'success' &&
             github.actor == 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
-            - name: Download Artifact
+            - name: Download artifact
               uses: actions/github-script@v6
               with:
                   script: |
@@ -40,8 +40,11 @@ jobs:
                       });
 
                       fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
-            - run: unzip pr.zip
-            - name: Comment on PR
+
+            - name: Unzip artifact
+              run: unzip pr.zip
+
+            - name: Merge PR
               uses: actions/github-script@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,6 +5,10 @@ on:
         workflows: ['CI']
         types: [completed]
 
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
     on-success:
         if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
             - 'docs/**'
             - '*.md'
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,34 +19,43 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [10, 12, 14, 16]
+                node: [10, 12, 14, 16]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v3
-            - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+            - name: Check out repo
+              uses: actions/checkout@v3
+
+            - name: Setup Node ${{ matrix.node }} on ${{ matrix.os }}
               uses: actions/setup-node@v3
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: ${{ matrix.node }}
+
             - name: Install
-              run: npm install --ignore-scripts
-            - name: Run Tests
+              run: npm i --ignore-scripts
+
+            - name: Run tests
               run: npm test
 
     # This job is used to save the PR number in an artifact, for use in the automerge.yml workflow
     save-pr-number:
-        name: Save PR Number
+        name: Save Dependabot PR Number
         if: >
-            github.event.pull_request.draft == false && 
-            github.event_name == 'pull_request'
+            github.event.pull_request.draft == false &&
+            github.event_name == 'pull_request' &&
+            github.actor == 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - name: Save PR Number
+            - name: Check out repo
+              uses: actions/checkout@v3
+
+            - name: Save PR number
               run: |
                   mkdir -p ./pr
                   echo ${{ github.event.number }} > ./pr/NR
-            - uses: actions/upload-artifact@v2
+
+            - name: Upload PR number in artifact
+              uses: actions/upload-artifact@v3
               with:
                   name: pr
                   path: pr/


### PR DESCRIPTION
This PR changes the following:

- Declares the minimum [permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) for CI workflows to run at the job level, following principle of least privilege; see [related security post](https://securitylab.github.com/research/github-actions-building-blocks/)
- Squashes automerge PRs to reduce noise
- Tidies up CI files to make them easier to follow