### PR TITLE
perf(lib): replace `lodash.merge()` with `Object.assign()`

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1,6 +1,5 @@
 const querystring = require('querystring');
 const crypto = require('crypto');
-const _ = require('lodash');
 const createCipher = require('./create-cipher');
 
 const ALGORITHM = 'aes256';
@@ -68,7 +67,7 @@ function clarify(s, options){
         const clarifiedKeys = querystring.parse(plaintext);
 
         // add the clarified keys
-        _.merge(allKeys, clarifiedKeys);
+        Object.assign(allKeys, clarifiedKeys);
 
         // remove the encrypted key
         delete allKeys[ENCRYPTEDKEY];

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
 		"url": "https://github.com/BlackPearSw/obfuscated-querystring/issues"
 	},
 	"homepage": "https://github.com/BlackPearSw/obfuscated-querystring#readme",
-	"dependencies": {
-		"lodash": "^4.17.20"
-	},
 	"devDependencies": {
 		"chai": "^4.2.0",
 		"mocha": "^9.0.1"


### PR DESCRIPTION
`Object.assign()` is a lot faster than `lodash.merge()`, see https://www.measurethat.net/Benchmarks/ShowResult/322166.

This PR also removes `lodash`, reducing the install size of this package.

Edit: From benchmarking, this reduces redirect times in [YDH's SIDeR Obfuscation Service](https://github.com/Fdawgs/ydh-sider-obfuscation-service) by a third.