### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         if: >
             github.event.pull_request.draft == false &&
             github.event_name == 'pull_request' &&
-            github.actor == 'dependabot[bot]'
+            github.event.pull_request.user.login == 'dependabot[bot]'
         runs-on: ubuntu-latest
         steps:
             - name: Check out repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node: [10, 12, 14, 16]
+                node: [14, 16, 18]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         steps:
             - name: Check out repo
               uses: actions/checkout@v3
+              with:
+                  persist-credentials: false
 
             - name: Setup Node ${{ matrix.node }} on ${{ matrix.os }}
               uses: actions/setup-node@v3
@@ -48,6 +50,8 @@ jobs:
         steps:
             - name: Check out repo
               uses: actions/checkout@v3
+              with:
+                  persist-credentials: false
 
             - name: Save PR number
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
 permissions:
     contents: read
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+    group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+    cancel-in-progress: true
+
 jobs:
     test:
         name: test


### PR DESCRIPTION
This PR:
-   Removes EOL node versions from test matrix, and adds node 18
-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
-   Enables `concurrency` in `ci.yml`; see [related docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency), this allows a subsequently queued workflow run to interrupt previous runs in PRs
