### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "https://github.com/BlackPearSw/obfuscated-querystring/issues"
 	},
 	"homepage": "https://github.com/BlackPearSw/obfuscated-querystring#readme",
+	"type": "commonjs",
 	"devDependencies": {
 		"chai": "^4.2.0",
 		"mocha": "^10.0.0"


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), which will probably become default in the future. Declaring the type will cause Node to skip detection on startup/compile, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.